### PR TITLE
Update .eslintrc.js

### DIFF
--- a/packages/insomnia-testing/.eslintrc.js
+++ b/packages/insomnia-testing/.eslintrc.js
@@ -1,9 +1,10 @@
-const { OFF, TYPESCRIPT_CONVERSION } = require('eslint-config-helpers');
+ const { OFF, TYPESCRIPT_CONVERSION } = require('eslint-config-helpers').rules;
 
 /** @type { import('eslint').Linter.Config } */
 module.exports = {
   extends: '../../.eslintrc.js',
   rules: {
-    '@typescript-eslint/no-use-before-define': OFF(TYPESCRIPT_CONVERSION),
+    '@typescript-eslint/no-use-before-define': OFF({ conversion: TYPESCRIPT_CONVERSION }),
   },
 };
+


### PR DESCRIPTION
The first error is with the line const { OFF, TYPESCRIPT_CONVERSION } = require('eslint-config-helpers'); and other error is with the @typescript-eslint/no-use-before-define rule configuration.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
